### PR TITLE
added possibility to use custom LXD image server when creating FDU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_install:
   - docker exec build bash -c "cd /root/ && git clone https://github.com/atolab/zenoh-c -b 0.3.0 --depth 1 && cd zenoh-c && make && make install"
   - docker exec build bash -c "cd /root/ && git clone https://github.com/atolab/zenoh-python -b 0.3.0 --depth 1 && cd zenoh-python && python3 setup.py install"
   - docker exec build bash -c "cd /root/ && git clone https://github.com/atolab/yaks-python -b 0.3.0 --depth 1 && cd yaks-python && make install"
-  - docker exec build bash -c "cd /root/ && git clone https://github.com/eclipse-fog05/sdk-python -b 0.1.x --depth 1 && cd sdk-python && make && make install"
-  - docker exec build bash -c "cd /root/ && git clone https://github.com/eclipse-fog05/api-python -b 0.1.x --depth 1 && cd api-python && make install"
+  - docker exec build bash -c "cd /root/ && git clone https://github.com/eclipse-fog05/sdk-python -b master --depth 1 && cd sdk-python && make && make install"
+  - docker exec build bash -c "cd /root/ && git clone https://github.com/eclipse-fog05/api-python -b master --depth 1 && cd api-python && make install"
   # copying repo inside container
   - docker cp ../plugin-fdu-lxd build:/root/
 script:
-  - docker exec build bash -c "mkdir /root/build && cd /root && cp -r plugin-fdu-lxd build/fog05-plugin-fdu-lxd-0.1 && cd build/fog05-plugin-fdu-lxd-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-plugin-fdu-lxd-0.1.tar.gz fog05-plugin-fdu-lxd-0.1"
-  - docker exec build bash -c "export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-plugin-fdu-lxd-0.1 && dh_make -f ../fog05-plugin-fdu-lxd-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-plugin-fdu-lxd-0.1 && printf "override_dh_auto_install:\n\tmkdir -p \$\$(pwd)/debian/fog05-plugin-fdu-lxd/lib/systemd/system/\n\t\$(MAKE) LXD_PLUGIN_DIR=\$\$(pwd)/debian/fog05-plugin-fdu-lxd/etc/fos/plugins/plugin-fdu-lxd SYSTEMD_DIR=\$\$(pwd)/debian/fog05-plugin-fdu-lxd/lib/systemd/system/ install">> debian/rules'
-  - docker exec build bash -c "cd /root/build/fog05-plugin-fdu-lxd-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l"
-  - docker exec build bash -c "cd /root/build/ && dpkg -I fog05-plugin-fdu-lxd_0.1-1_amd64.deb"
+  - docker exec build bash -c "mkdir /root/build && cd /root && cp -r plugin-fdu-lxd build/fog05-plugin-fdu-lxd-0.2 && cd build/fog05-plugin-fdu-lxd-0.2 && rm -rf .git && make clean && cd .. && tar -czvf fog05-plugin-fdu-lxd-0.2.tar.gz fog05-plugin-fdu-lxd-0.2"
+  - docker exec build bash -c "export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-plugin-fdu-lxd-0.2 && dh_make -f ../fog05-plugin-fdu-lxd-0.2.tar.gz -s -y"
+  - docker exec build bash -c 'cd /root/build/fog05-plugin-fdu-lxd-0.2 && printf "override_dh_auto_install:\n\tmkdir -p \$\$(pwd)/debian/fog05-plugin-fdu-lxd/lib/systemd/system/\n\t\$(MAKE) LXD_PLUGIN_DIR=\$\$(pwd)/debian/fog05-plugin-fdu-lxd/etc/fos/plugins/plugin-fdu-lxd SYSTEMD_DIR=\$\$(pwd)/debian/fog05-plugin-fdu-lxd/lib/systemd/system/ install">> debian/rules'
+  - docker exec build bash -c "cd /root/build/fog05-plugin-fdu-lxd-0.2 && debuild --preserve-envvar PATH -us -uc  && ls -l"
+  - docker exec build bash -c "cd /root/build/ && dpkg -I fog05-plugin-fdu-lxd_0.2-1_amd64.deb"

--- a/LXD_plugin
+++ b/LXD_plugin
@@ -217,16 +217,21 @@ class LXD(RuntimePluginFDU):
         img_info = {}
         try:
 
-            if fdu.get_image_uri().startswith('lxd://') or fdu.get_image_uri().startswith('ubuntu://'):
+            if fdu.get_image_uri().startswith('lxd://') or fdu.get_image_uri().startswith('ubuntu://') or fdu.get_image_uri().startswith('custom://'):
                 try:
                     if fdu.get_image_uri().startswith('lxd://'):
                         img_alias = fdu.get_image_uri()[6:]
                         self.logger.info('define_fdu()','Image is coming from LXD repository: {}'.format(img_alias))
                         lxd_img = self.conn.images.create_from_simplestreams(server=self.IMAGE_SERVER, alias=img_alias)
-                    else:
+                    elif fdu.get_image_uri().startswith('ubuntu://'):
                         img_alias = fdu.get_image_uri()[9:]
                         self.logger.info('define_fdu()','Image is coming from Ubuntu repository: {}'.format(img_alias))
                         lxd_img = self.conn.images.create_from_simplestreams(server=self.UBUNTU_IMAGE_SERVER, alias=img_alias)
+                    else:
+                        img_alias = '/'.join(fdu.get_image_uri()[9:].split('/')[-2:])
+                        img_server = 'https://{}'.format('/'.join(fdu.get_image_uri()[9:].split('/')[:-2]))
+                        self.logger.info('define_fdu()','Image is coming from Custom repository: {} - {}'.format(img_server, img_alias))
+                        lxd_img = self.conn.images.create_from_simplestreams(server=img_server, alias=img_alias)
                     lxd_img.add_alias(fdu_uuid, description='')
                 except LXDAPIException as e:
                     self.logger.info('define_fdu()', '[ ERRO ] LXD Plugin - LXDAPIException when fetching image: {}'.format(e))
@@ -737,16 +742,21 @@ class LXD(RuntimePluginFDU):
                         self.os.execute_command(cmd, blocking=True)
                 img_info = {}
                 try:
-                    if record.get_image_uri().startswith('lxd://') or record.get_image_uri().startswith('ubuntu://'):
+                    if fdu.get_image_uri().startswith('lxd://') or fdu.get_image_uri().startswith('ubuntu://') or fdu.get_image_uri().startswith('custom://'):
                         try:
-                            if record.get_image_uri().startswith('lxd://'):
-                                img_alias = record.get_image_uri()[6:]
-                                self.logger.info('migrate_fdu()','Image is coming from LXD repository: {}'.format(img_alias))
+                            if fdu.get_image_uri().startswith('lxd://'):
+                                img_alias = fdu.get_image_uri()[6:]
+                                self.logger.info('define_fdu()','Image is coming from LXD repository: {}'.format(img_alias))
                                 lxd_img = self.conn.images.create_from_simplestreams(server=self.IMAGE_SERVER, alias=img_alias)
-                            else:
-                                img_alias = record.get_image_uri()[9:]
-                                self.logger.info('migrate_fdu()','Image is coming from Ubuntu repository: {}'.format(img_alias))
+                            elif fdu.get_image_uri().startswith('ubuntu://'):
+                                img_alias = fdu.get_image_uri()[9:]
+                                self.logger.info('define_fdu()','Image is coming from Ubuntu repository: {}'.format(img_alias))
                                 lxd_img = self.conn.images.create_from_simplestreams(server=self.UBUNTU_IMAGE_SERVER, alias=img_alias)
+                            else:
+                                img_alias = '/'.join(fdu.get_image_uri()[9:].split('/')[-2:])
+                                img_server = 'https://{}'.format('/'.join(fdu.get_image_uri()[9:].split('/')[:-2]))
+                                self.logger.info('define_fdu()','Image is coming from Custom repository: {} - {}'.format(img_server, img_alias))
+                                lxd_img = self.conn.images.create_from_simplestreams(server=img_server, alias=img_alias)
                             lxd_img.add_alias(fdu_uuid, description='')
                         except LXDAPIException as e:
                             self.logger.info('migrate_fdu()', '[ ERRO ] LXD Plugin - LXDAPIException when fetching image: {}'.format(e))


### PR DESCRIPTION
Adding the possibility to use a custom image server in FDU definition.
Custom image server can be defined using the `custom://` schema in the URI.


```
    },
    "image": {
        "uri": "custom://custom.image.server/images/image/tag",
        "checksum": "",
```

It always expect the image to be passed as `image/tag`

